### PR TITLE
Use quote_ident for bloat query

### DIFF
--- a/pgFirstAid.sql
+++ b/pgFirstAid.sql
@@ -89,8 +89,8 @@ select
 	pt.schemaname || '.' || pt.tablename as object_name,
 	'Table has significant bloat affecting performance and storage' as issue_description,
 	'Estimated bloat: ' || ROUND(
-        case when pg_relation_size(pt.schemaname || '.' || pt.tablename) > 0
-        then (pg_relation_size(pt.schemaname || '.' || pt.tablename) - pg_relation_size(pt.schemaname || '.' || pt.tablename, 'main')) * 100.0 / pg_relation_size(pt.schemaname || '.' || pt.tablename)
+        case when pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename)) > 0
+        then (pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename)) - pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename), 'main')) * 100.0 / pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename))
         else 0 end, 2
     ) || '%' as current_value,
 	'Run VACUUM FULL to reclaim space' as recommended_action,
@@ -100,9 +100,9 @@ from
 	pg_tables pt
 where
 	pt.schemaname not in ('information_schema', 'pg_catalog', 'pg_toast')
-	and pg_relation_size(pt.schemaname || '.' || pt.tablename) > 104857600
+	and pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename)) > 104857600
 	-- 100MB
-	and (pg_relation_size(pt.schemaname || '.' || pt.tablename) - pg_relation_size(pt.schemaname || '.' || pt.tablename, 'main')) * 100.0 / nullif(pg_relation_size(pt.schemaname || '.' || pt.tablename), 0) > 20;
+	and (pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename)) - pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename), 'main')) * 100.0 / nullif(pg_relation_size(pt.schemaname || '.' || quote_ident(pt.tablename)), 0) > 20;
 -- 4. HIGH: Tables never analyzed
     insert
 	into


### PR DESCRIPTION
## Pull Request Summary

Not gonna lie I'm not very familiar with Postgres stuff but this made the script work for me and it shouldn't break anything if what I read online is correct.

The script failed with "relation does not exist" when it definitely does. My tables are case sensitive for some reason and wrapping `pt.table_name` with `quote_ident()` makes it work.

### Type of Change

- [X] Bug fix

## Testing

### PostgreSQL Version Compatibility

**Has this code been tested against the following PostgreSQL versions?**

- [ ] PostgreSQL 15
- [ ] PostgreSQL 16
- [X] PostgreSQL 17
- [ ] PostgreSQL 18 (if available)

### Managed Database Platforms

**Has this code been deployed and tested on the following platforms?**

- [ ] Amazon RDS for PostgreSQL
- [ ] Amazon Aurora PostgreSQL
- [ ] Google Cloud SQL for PostgreSQL
- [ ] Azure Database for PostgreSQL
- [ ] Self-managed PostgreSQL
- [X] Not applicable / Not tested yet

---

## Checklist

- [X] Code follows project style guidelines
- [X] Self-review of code completed
- [X] Code comments added for complex logic
- [X] No sensitive information (credentials, internal URLs) included
- [X] Tested locally before submitting
- [X] All checks marked above are complete
