### PR TITLE
Feat/enhance ci

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,6 +83,11 @@ Branches should follow the pattern `type/description`, where `type` is one of th
 | `doc/` | Documentation changes |
 | `docs/` | Documentation changes (alternative to `doc/`) |
 | `test/` | Adding or fixing tests |
+| `perf/` | Performance improvements |
+| `style/` | Formatting or lint-only changes |
+| `ci/` | CI/CD configuration changes |
+| `build/` | Build or packaging changes |
+| `revert/` | Reverting a previous change |
 | `refactor/` | Code restructuring without behavior changes |
 
 Examples:
@@ -92,6 +97,11 @@ feat/inactive-replication-slot-check
 fix/duplicate-index-predicate-matching
 docs/update-contributing-guide
 test/pgtap-blocked-session-coverage
+perf/reduce-duplicate-index-scan-work
+style/normalize-sql-indentation
+ci/add-postgres-18-matrix-job
+build/update-integration-harness-setup
+revert/remove-blocked-session-text-change
 refactor/align-view-check-ordering
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,15 +8,92 @@ This project follows the [Contributor Covenant](https://www.contributor-covenant
 
 ## Ways to Contribute
 
-- **New health checks** - Propose or implement checks for database issues not yet covered. Use `feature/` for new health checks
-- **Bug fixes** - Found something broken? PRs welcome. Use `bug/` for bug fix branches
-- **Documentation** - Improve README, add examples, clarify explanations. Use `docs/` for any documentation releated contributions
+- **New health checks** - Propose or implement checks for database issues not yet covered
+- **Bug fixes** - Found something broken? PRs welcome
+- **Documentation** - Improve README, add examples, or clarify explanations
 - **Testing** - Validate checks across PostgreSQL versions and cloud providers
 - **Feature requests** - Open an issue describing your idea
 
 ## Development Setup
 
 The `testing/` directory contains integration and pgTAP coverage used to validate pgFirstAid against live PostgreSQL environments. You can run the test suite against any database you control by setting the standard PostgreSQL connection environment variables described in `testing/integration/README.md`.
+
+## Conventional Commits
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). Every commit message should use this format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+[optional footer(s)]
+```
+
+### Types
+
+| Type | Usage | pgFirstAid example |
+|------|-------|--------------------|
+| `feat` | A new feature | `feat(checks): add check for inactive replication slots` |
+| `fix` | A bug fix | `fix(indexes): avoid false positives for partial duplicate indexes` |
+| `chore` | Maintenance, tooling, dependencies | `chore(ci): update PostgreSQL 18 test coverage` |
+| `docs` | Documentation changes | `docs: clarify managed view installation steps` |
+| `test` | Adding or fixing tests | `test(pgtap): cover long-running query check` |
+| `refactor` | Code restructuring with no behavior change | `refactor(views): align duplicate index query across install targets` |
+| `style` | Formatting or linting with no logic change | `style: normalize SQL indentation in pgFirstAid.sql` |
+| `perf` | Performance improvement | `perf(checks): reduce work in duplicate index detection` |
+| `ci` | CI/CD configuration | `ci: run integration suite against PostgreSQL 18` |
+| `build` | Build or packaging changes | `build: update integration harness setup` |
+| `revert` | Reverting a previous change | `revert: restore previous blocked session recommendation text` |
+
+### Scopes
+
+The optional scope should reference the part of the project you changed:
+
+- `checks` - health check SQL logic
+- `views` - `view_pgFirstAid.sql` and `view_pgFirstAid_managed.sql`
+- `indexes` - duplicate index and index-related checks
+- `sessions` - session and blocking query checks
+- `pgtap` - pgTAP coverage in `testing/pgTAP/`
+- `integration` - Python integration tests in `testing/integration/`
+- `ci` - GitHub Actions and CI configuration
+- `docs` - README and contribution docs
+- `deps` - dependency updates
+- `release` - release preparation
+
+### Examples
+
+```
+feat(checks): add lock timeout recommendation for blocked sessions
+fix(views): keep managed and self-hosted duplicate index checks aligned
+docs: add contribution guidance for test coverage
+test(integration): verify long-running query output on seeded data
+chore(deps): update pytest in integration harness
+```
+
+## Branch Naming
+
+Branches should follow the pattern `type/description`, where `type` is one of the following:
+
+| Branch prefix | When to use |
+|---------------|-------------|
+| `feat/` | New features |
+| `feature/` | New features (alternative to `feat/`) |
+| `fix/` | Bug fixes |
+| `chore/` | Maintenance tasks and dependency updates |
+| `doc/` | Documentation changes |
+| `docs/` | Documentation changes (alternative to `doc/`) |
+| `test/` | Adding or fixing tests |
+| `refactor/` | Code restructuring without behavior changes |
+
+Examples:
+
+```
+feat/inactive-replication-slot-check
+fix/duplicate-index-predicate-matching
+docs/update-contributing-guide
+test/pgtap-blocked-session-coverage
+refactor/align-view-check-ordering
+```
 
 ## Testing Requirements
 
@@ -39,16 +116,18 @@ Not everyone has access to all environments. Document what you tested in your PR
 ## Submitting a Pull Request
 
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/new-health-check`)
+2. Create a branch following the naming convention above (`git checkout -b feat/new-health-check`)
 3. Make your changes
-4. Test against available PostgreSQL versions
-5. Submit a PR using the provided template
+4. Keep commits focused and follow Conventional Commits
+5. Test against available PostgreSQL versions
+6. Submit a PR using the provided template
 
 ### PR Review Process
 
 - At least 1 maintainer must approve before merging
 - Be patient—this is a side project maintained in spare time
 - Expect acknowledgment within a reasonable timeframe, with detailed review to follow
+- Squash-merge is preferred. The final commit message should also follow Conventional Commits
 
 ## SQL Style Guidelines
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,67 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+
+categories:
+  - title: "Features"
+    labels:
+      - "feat"
+  - title: "Bug Fixes"
+    labels:
+      - "fix"
+  - title: "Documentation"
+    labels:
+      - "docs"
+  - title: "Refactoring"
+    labels:
+      - "refactor"
+  - title: "Testing"
+    labels:
+      - "test"
+  - title: "Chores"
+    labels:
+      - "chore"
+  - title: "Performance"
+    labels:
+      - "perf"
+  - title: "CI/CD"
+    labels:
+      - "ci"
+  - title: "Build"
+    labels:
+      - "build"
+  - title: "Reverts"
+    labels:
+      - "revert"
+
+change-template: "- $TITLE (#$NUMBER) by @$AUTHOR"
+change-title-escapes: '\<*_&'
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking"
+  minor:
+    labels:
+      - "minor"
+      - "feat"
+  patch:
+    labels:
+      - "patch"
+      - "fix"
+      - "docs"
+      - "refactor"
+      - "test"
+      - "chore"
+      - "perf"
+      - "ci"
+      - "build"
+      - "revert"
+  default: patch
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,43 @@
 name-template: "v$RESOLVED_VERSION"
 tag-template: "v$RESOLVED_VERSION"
 
+autolabeler:
+  - label: "feat"
+    branch:
+      - '/feat\/.+/'
+      - '/feature\/.+/'
+  - label: "fix"
+    branch:
+      - '/fix\/.+/'
+  - label: "docs"
+    branch:
+      - '/doc\/.+/'
+      - '/docs\/.+/'
+  - label: "test"
+    branch:
+      - '/test\/.+/'
+  - label: "refactor"
+    branch:
+      - '/refactor\/.+/'
+  - label: "chore"
+    branch:
+      - '/chore\/.+/'
+  - label: "perf"
+    branch:
+      - '/perf\/.+/'
+  - label: "style"
+    branch:
+      - '/style\/.+/'
+  - label: "ci"
+    branch:
+      - '/ci\/.+/'
+  - label: "build"
+    branch:
+      - '/build\/.+/'
+  - label: "revert"
+    branch:
+      - '/revert\/.+/'
+
 categories:
   - title: "Features"
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -60,6 +60,9 @@ categories:
   - title: "Performance"
     labels:
       - "perf"
+  - title: "Style"
+    labels:
+      - "style"
   - title: "CI/CD"
     labels:
       - "ci"
@@ -91,6 +94,7 @@ version-resolver:
       - "test"
       - "chore"
       - "perf"
+      - "style"
       - "ci"
       - "build"
       - "revert"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,10 +17,10 @@ permissions:
 
 jobs:
   autolabel-pr:
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == false
     permissions:
       pull-requests: write
-    runs-on: [self-hosted, nix, nixos, x86_64-linux]
+    runs-on: ubuntu-latest
     steps:
       - name: Apply release-drafter labels
         uses: release-drafter/release-drafter/autolabeler@v6 # v6.1.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,16 +4,33 @@ on:
   push:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 permissions:
   contents: read
 
 jobs:
+  autolabel-pr:
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      pull-requests: write
+    runs-on: [self-hosted, nix, nixos, x86_64-linux]
+    steps:
+      - name: Apply release-drafter labels
+        uses: release-drafter/release-drafter/autolabeler@v6 # v6.1.0
+
   update-release-draft:
+    if: github.event_name == 'push'
     permissions:
       contents: write
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, nix, nixos, x86_64-linux]
     steps:
       - name: Draft release notes
         uses: release-drafter/release-drafter@v6 # v6.1.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update-release-draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft release notes
+        uses: release-drafter/release-drafter@v6 # v6.1.0
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Pull Request Summary

<!-- Provide a brief description of what this PR accomplishes -->
The following PR adds a release drafter through CI and updated the `CONTRIBUTING.md` to reflect conventional commit messages and branch naming.

### Type of Change

- [ ] New health check
- [ ] Bug fix
- [ ] Performance improvement
- [x] Documentation update
- [ ] Refactoring/code cleanup
- [ ] Breaking change

---

## Related Issues

<!-- Link any related GitHub issues -->

- Fixes #<!-- issue number -->
- Related to #<!-- issue number -->
- Closes #<!-- issue number -->


---

## Testing

### PostgreSQL Version Compatibility

**Has this code been tested against the following PostgreSQL versions?**

- [ ] PostgreSQL 15
- [ ] PostgreSQL 16
- [ ] PostgreSQL 17
- [ ] PostgreSQL 18

**Testing notes:**
<!-- Describe any version-specific behavior or issues discovered -->

### Managed Database Platforms

**Has this code been deployed and tested on the following platforms?**

- [ ] Amazon RDS for PostgreSQL
- [ ] Google Cloud SQL for PostgreSQL (currently unable to test)
- [ ] Azure Database for PostgreSQL (currently unable to test)
- [ ] Neon 
- [ ] Supabase
- [ ] Self-managed PostgreSQL

**Platform-specific notes:**
<!-- Describe any platform-specific behavior, limitations, or compatibility issues -->

---

## Additional Notes

<!-- Any other information relevant to reviewers -->

---

<!-- greptile_comment -->

<details open><summary><h3>Security Review</h3></summary>

- **Self-hosted runner exposure via `pull_request_target`** (`.github/workflows/release-drafter.yml`): The `autolabel-pr` job triggers on `pull_request_target` from any fork PR and runs on a self-hosted runner. For a public repo this lets any external contributor execute jobs on internal infrastructure. Recommend switching the autolabeler job to `ubuntu-latest`.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-drafter.yml | New workflow using pull_request_target with self-hosted runners — security risk for a public repo; autolabeler and release-draft jobs are otherwise correctly structured |
| .github/release-drafter.yml | New release-drafter config with full autolabeler; `style` label is defined but missing from categories and version-resolver patch labels, causing style PRs to be dropped from release notes |
| .github/CONTRIBUTING.md | Adds Conventional Commits guidance and a complete branch naming table covering all commit types; minor editorial cleanup throughout |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(ci): reso from greptile"](https://github.com/randoneering/pgfirstaid/commit/97a863a22469a5706fb336f75d78126726a4033e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32545657)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->