### PR TITLE
fix(ci): replace dead actions-setup-postgres with apt postgresql-client

### DIFF
--- a/.github/workflows/neon-before-after-validate.yml
+++ b/.github/workflows/neon-before-after-validate.yml
@@ -82,11 +82,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: 'ephemeral'
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Set branch name
         id: branch-name

--- a/workflows/db-health-checks.yml
+++ b/workflows/db-health-checks.yml
@@ -34,11 +34,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: ${{ secrets.PGPASSWORD }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Install pgFirstAid
         run: |
@@ -173,11 +173,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: ${{ secrets.PGPASSWORD }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Install pgFirstAid
         run: |

--- a/workflows/managed-db-validate.yml
+++ b/workflows/managed-db-validate.yml
@@ -68,11 +68,11 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ inputs.region }}
 
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: ${{ secrets.AWS_RDS_PASSWORD }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Resolve RDS Endpoint
         id: rds-endpoint
@@ -215,11 +215,11 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: ${{ secrets.GCP_CLOUD_SQL_PASSWORD }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Resolve Cloud SQL Endpoint
         id: cloudsql-endpoint
@@ -360,11 +360,11 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: ${{ secrets.AZURE_POSTGRESQL_PASSWORD }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Resolve Azure PostgreSQL Endpoint
         id: azure-endpoint

--- a/workflows/neon-before-after-validate.yml
+++ b/workflows/neon-before-after-validate.yml
@@ -82,11 +82,11 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: 'ephemeral'
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Set branch name
         id: branch-name

--- a/workflows/pre-post-migration-validate.yml
+++ b/workflows/pre-post-migration-validate.yml
@@ -35,11 +35,11 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: ${{ secrets.PGPASSWORD }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -159,11 +159,11 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - name: Set up PostgreSQL client
-        uses: shogo82148/actions-setup-postgres@v1
-        with:
-          postgres-version: 16
-          postgres-password: ${{ secrets.PGPASSWORD }}
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client >/dev/null
+          psql --version
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Pull Request Summary

<!-- Provide a brief description of what this PR accomplishes -->

The shogo82148/actions-setup-postgres@v1 action has been removed from
the GitHub Marketplace, causing every workflow that references it to
fail with "Unable to resolve action ... repository not found".

Replace the action in all 9 step locations across 5 workflow files
with an inline apt install of postgresql-client. The action only
provisioned a local psql binary, so swap is behaviour-preserving.

### Type of Change

- [ ] New health check
- [x] Bug fix
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Refactoring/code cleanup
- [ ] Breaking change

---

## Related Issues

<!-- Link any related GitHub issues -->

- Fixes #<!-- issue number -->
- Related to #<!-- issue number -->
- Closes #<!-- issue number -->


---

## Testing

### PostgreSQL Version Compatibility

**Has this code been tested against the following PostgreSQL versions?**

- [ ] PostgreSQL 15
- [ ] PostgreSQL 16
- [ ] PostgreSQL 17
- [ ] PostgreSQL 18

**Testing notes:**
<!-- Describe any version-specific behavior or issues discovered -->

### Managed Database Platforms

**Has this code been deployed and tested on the following platforms?**

- [ ] Amazon RDS for PostgreSQL
- [ ] Google Cloud SQL for PostgreSQL (currently unable to test)
- [ ] Azure Database for PostgreSQL (currently unable to test)
- [ ] Neon 
- [ ] Supabase
- [ ] Self-managed PostgreSQL

**Platform-specific notes:**
<!-- Describe any platform-specific behavior, limitations, or compatibility issues -->

---

## Additional Notes

<!-- Any other information relevant to reviewers -->

---

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

All affected jobs run on `ubuntu-latest`, which supports the new installation commands. Downstream database steps provide credentials directly through environment variables or connection URLs. No blocking issues found in the changed code.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Generated and made executable the psql provisioning validation harness used to drive both baseline and after captures.
- Captured the psql provisioning baseline against HEAD^ and recorded five YAML parse results plus the 0/9 structural counts.
- Executed the exact apt provisioning commands and captured the after-state, including five YAML parse results, all nine locations, zero legacy references, and psql --version output.
- Reviewed the uploaded baseline and after provisioning logs via their URLs to verify the captures.

<a href="https://app.greptile.com/trex/runs/15496564/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): replace dead actions-setup-post..."](https://github.com/randoneering/pgfirstaid/commit/3d0293ba4240c38259514e5379079e7f94ca89a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46500334)</sub>

<!-- /greptile_comment -->